### PR TITLE
Fixing bug where event params were not passed correctly.

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -137,19 +137,19 @@ var Typeahead = (function() {
       if (this.autoselect) {
         this.menu.setCursor(this.menu.getTopSelectable());
       }
-      this.eventBus.trigger('render', suggestions, async, dataset);
+      this.eventBus.trigger('render', [suggestions, async, dataset]);
     },
 
     _onAsyncRequested: function onAsyncRequested(type, dataset, query) {
-      this.eventBus.trigger('asyncrequest', query, dataset);
+      this.eventBus.trigger('asyncrequest', [query, dataset]);
     },
 
     _onAsyncCanceled: function onAsyncCanceled(type, dataset, query) {
-      this.eventBus.trigger('asynccancel', query, dataset);
+      this.eventBus.trigger('asynccancel', [query, dataset]);
     },
 
     _onAsyncReceived: function onAsyncReceived(type, dataset, query) {
-      this.eventBus.trigger('asyncreceive', query, dataset);
+      this.eventBus.trigger('asyncreceive', [query, dataset]);
     },
 
     _onFocused: function onFocused() {
@@ -158,7 +158,7 @@ var Typeahead = (function() {
 
     _onBlurred: function onBlurred() {
       if (this.input.hasQueryChangedSinceLastFocus()) {
-        this.eventBus.trigger('change', this.input.getQuery());
+        this.eventBus.trigger('change', [this.input.getQuery()]);
       }
     },
 
@@ -358,7 +358,7 @@ var Typeahead = (function() {
       data = this.menu.getSelectableData($selectable);
       dataset = this.menu.getSelectableDataset($selectable);
 
-      if (data && !this.eventBus.before('select', data.obj)) {
+      if (data && !this.eventBus.before('select', [data.obj])) {
         this.input.setQuery(data.val, true);
 
         this.eventBus.trigger('select', [data.obj, dataset]);
@@ -378,9 +378,9 @@ var Typeahead = (function() {
       data = this.menu.getSelectableData($selectable);
       isValid = data && query !== data.val;
 
-      if (isValid && !this.eventBus.before('autocomplete', data.obj)) {
+      if (isValid && !this.eventBus.before('autocomplete', [data.obj])) {
         this.input.setQuery(data.val);
-        this.eventBus.trigger('autocomplete', data.obj);
+        this.eventBus.trigger('autocomplete', [data.obj]);
 
         // return true if autocompletion succeeded
         return true;
@@ -401,7 +401,7 @@ var Typeahead = (function() {
       // need to be fetched – in this case we don't want to move the cursor
       cancelMove = this._minLengthMet() && this.menu.update(query);
 
-      if (!cancelMove && !this.eventBus.before('cursorchange', payload)) {
+      if (!cancelMove && !this.eventBus.before('cursorchange', [payload])) {
         this.menu.setCursor($candidate);
 
         // cursor moved to different selectable
@@ -415,7 +415,7 @@ var Typeahead = (function() {
           this._updateHint();
         }
 
-        this.eventBus.trigger('cursorchange', payload);
+        this.eventBus.trigger('cursorchange', [payload]);
 
         // return true if move succeeded
         return true;

--- a/test/typeahead/typeahead_spec.js
+++ b/test/typeahead/typeahead_spec.js
@@ -73,6 +73,7 @@ describe('Typeahead', function() {
         this.$input.on('typeahead:asyncrequest', spy);
         this.menu.trigger(eventName);
         expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args.length).toBe(3);
     });
   });
 
@@ -89,6 +90,7 @@ describe('Typeahead', function() {
         this.$input.on('typeahead:asynccancel', spy);
         this.menu.trigger(eventName);
         expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args.length).toBe(3);
     });
   });
 
@@ -105,6 +107,7 @@ describe('Typeahead', function() {
         this.$input.on('typeahead:asyncreceive', spy);
         this.menu.trigger(eventName);
         expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args.length).toBe(3);
     });
   });
 
@@ -149,6 +152,7 @@ describe('Typeahead', function() {
         this.$input.on('typeahead:render', spy);
         this.menu.trigger(eventName);
         expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args.length).toBe(4);
       });
     });
   });
@@ -254,6 +258,7 @@ describe('Typeahead', function() {
       this.input.trigger(eventName);
 
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(2);
     });
 
     it('should not trigger typeahead:change if query has not changed since focus', function() {
@@ -1202,6 +1207,7 @@ describe('Typeahead', function() {
       this.view.select($('<bah>'));
 
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(2);
     });
 
     it('should support cancellation', function() {
@@ -1234,6 +1240,7 @@ describe('Typeahead', function() {
       this.view.select($('<bah>'));
 
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(3);
     });
 
     it('should close', function() {
@@ -1268,6 +1275,7 @@ describe('Typeahead', function() {
       this.view.autocomplete($('<bah>'));
 
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(2);
     });
 
     it('should support cancellation', function() {
@@ -1348,6 +1356,7 @@ describe('Typeahead', function() {
       this.$input.on('typeahead:beforecursorchange', spy);
       this.view.moveCursor(1);
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(2);
     });
 
     it('should support cancellation', function() {
@@ -1390,6 +1399,7 @@ describe('Typeahead', function() {
       this.$input.on('typeahead:cursorchange', spy);
       this.view.moveCursor(1);
       expect(spy).toHaveBeenCalled();
+      expect(spy.mostRecentCall.args.length).toBe(2);
     });
   });
 


### PR DESCRIPTION
Plugin events run through a trigger method, which assumes the arguments will be an array.  In their own calling code though, they do not wrap arguments in an array, which caused odd behavior when they sliced the arg data.  This change is to wrap the event args in an array as it probably should have been originally.
