### PR TITLE
Fixing bug where result count equal to limit does not render anything.

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -270,8 +270,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
This fixes the issue we are seeing when searching for "nosql" which happened to hit an odd bug in this plugin.
